### PR TITLE
test: fix race condition in tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Go mod verify
         run: go mod verify
       - name: Run tests
-        run: go test -count=1 -v ./...
+        run: go test -race -count=1 -v ./...
 
   ci:
     needs:

--- a/plan_test.go
+++ b/plan_test.go
@@ -152,7 +152,7 @@ func TestPlan_UnmarshalJSON(t *testing.T) {
 
 			plan.UseJSONNumber(testCase.useJSONNumber)
 
-			err = plan.UnmarshalJSON(b)
+			err := plan.UnmarshalJSON(b)
 
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This fixes the detected races below:

```
WARNING: DATA RACE
Write at 0x00c0013a0fa0 by goroutine 95:
  github.com/hashicorp/terraform-json.TestPlan_UnmarshalJSON.func1()
      /home/runner/work/tfjson/tfjson/plan_test.go:155 +0x149
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.12/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.12/x64/src/testing/testing.go:1648 +0x44

Previous write at 0x00c0013a0fa0 by goroutine 96:
  github.com/hashicorp/terraform-json.TestPlan_UnmarshalJSON.func1()
      /home/runner/work/tfjson/tfjson/plan_test.go:155 +0x149
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.12/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.12/x64/src/testing/testing.go:1648 +0x44

Goroutine 95 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.21.12/x64/src/testing/testing.go:1648 +0x845
  github.com/hashicorp/terraform-json.TestPlan_UnmarshalJSON()
      /home/runner/work/tfjson/tfjson/plan_test.go:148 +0x32b
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.12/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.12/x64/src/testing/testing.go:1648 +0x44

Goroutine 96 (finished) created at:
  testing.(*T).Run()
```