### PR TITLE
feat: bump to v2

### DIFF
--- a/cmd/round-trip-dumper/main.go
+++ b/cmd/round-trip-dumper/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terramate-io/tfjson
+module github.com/terramate-io/tfjson/v2
 
 go 1.20
 

--- a/sanitize/sanitize_change.go
+++ b/sanitize/sanitize_change.go
@@ -4,7 +4,7 @@
 package sanitize
 
 import (
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 // SanitizeChange traverses a Change and replaces all values at

--- a/sanitize/sanitize_change_test.go
+++ b/sanitize/sanitize_change_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 type testChangeCase struct {

--- a/sanitize/sanitize_config.go
+++ b/sanitize/sanitize_config.go
@@ -1,6 +1,6 @@
 package sanitize
 
-import "github.com/terramate-io/tfjson"
+import "github.com/terramate-io/tfjson/v2"
 
 // SanitizeProviderConfigs sanitises the constant_value from expressions of the provider_configs to the value set in replaceWith parameter.
 func SanitizeProviderConfigs(result map[string]*tfjson.ProviderConfig, replaceWith interface{}) {

--- a/sanitize/sanitize_plan.go
+++ b/sanitize/sanitize_plan.go
@@ -6,7 +6,7 @@ package sanitize
 import (
 	"errors"
 
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 const DefaultSensitiveValue = "REDACTED_SENSITIVE"

--- a/sanitize/sanitize_plan_test.go
+++ b/sanitize/sanitize_plan_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/sebdah/goldie/v2"
 
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 const testDataDir = "testdata"

--- a/sanitize/sanitize_plan_variables.go
+++ b/sanitize/sanitize_plan_variables.go
@@ -4,7 +4,7 @@
 package sanitize
 
 import (
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 // SanitizePlanVariables traverses a map of PlanVariable and replaces

--- a/sanitize/sanitize_plan_variables_test.go
+++ b/sanitize/sanitize_plan_variables_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 type testVariablesCase struct {

--- a/sanitize/sanitize_state.go
+++ b/sanitize/sanitize_state.go
@@ -6,7 +6,7 @@ package sanitize
 import (
 	"fmt"
 
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 type SanitizeStateModuleChangeMode string

--- a/sanitize/sanitize_state_test.go
+++ b/sanitize/sanitize_state_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 
-	"github.com/terramate-io/tfjson"
+	"github.com/terramate-io/tfjson/v2"
 )
 
 type testStateCase struct {


### PR DESCRIPTION
As https://github.com/terramate-io/tfjson/pull/14 caused a breaking change we need to bump the library to version 2 in accordance with semver.